### PR TITLE
Relax setuptools build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=65.6", "wheel~=0.37.1"]
+requires = ["setuptools>=65.6"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Given that setuptools is already at version 68.1.2 and iterates quickly, would you be OK with not capping the version until a version is released that is noticed to break the build?

I also removed listing wheel explicitly because according to the [setuptools documentation](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use):

> Historically this documentation has unnecessarily listed wheel in the requires list, and many projects still do that. This is not recommended. The backend automatically adds wheel dependency when it is required, and listing it explicitly causes it to be unnecessarily required for source distribution builds. You should only include wheel in requires if you need to explicitly access it during build time (e.g. if your project needs a setup.py script that imports wheel).